### PR TITLE
[FEAT] 사용자 조회 및 삭제

### DIFF
--- a/com.sparta.logistics.client.auth/src/main/java/com/sparta/logistics/client/auth/application/security/SecurityUserDetails.java
+++ b/com.sparta.logistics.client.auth/src/main/java/com/sparta/logistics/client/auth/application/security/SecurityUserDetails.java
@@ -35,7 +35,7 @@ public class SecurityUserDetails implements UserDetails {
         return authorities;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return securityUserInfo.getId();
     }
 

--- a/com.sparta.logistics.client.auth/src/main/java/com/sparta/logistics/client/auth/infrastructure/feign/UserClient.java
+++ b/com.sparta.logistics.client.auth/src/main/java/com/sparta/logistics/client/auth/infrastructure/feign/UserClient.java
@@ -13,6 +13,6 @@ public interface UserClient {
     @PostMapping("/users")
     UserVO createUser(@RequestBody UserRequest userRequest);
 
-    @GetMapping("/users/{username}")
+    @GetMapping("/users/auth/{username}")
     UserVO findByUsername(@PathVariable("username") String username);
 }

--- a/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/application/service/UserService.java
+++ b/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/application/service/UserService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    @Transactional
     public UserVO createUser(UserRequest userRequest) {
         log.info("Attempting to create user: {}", userRequest.getUsername());
         User user = User.createUser(
@@ -34,10 +35,22 @@ public class UserService {
             throw new IllegalArgumentException("User already exists");
         }
     }
-
+    @Transactional(readOnly = true)
     public UserVO findByUsername(String username) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new IllegalArgumentException("User not found with username: " + username));
         return user.toUserVO();
+    }
+    @Transactional(readOnly = true)
+    public UserVO getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+        return user.toUserVO();
+    }
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+        user.delete(user.getId());
     }
 }

--- a/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/presentation/controller/UserController.java
+++ b/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/presentation/controller/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
         return ResponseEntity.ok(userVO);
     }
 
-    @GetMapping("/{username}")
+    @GetMapping("/auth/{username}")
     public ResponseEntity<UserVO> findByUsername(@PathVariable String username) {
         UserVO user = userService.findByUsername(username);
         if (user != null) {
@@ -28,4 +28,15 @@ public class UserController {
             return ResponseEntity.notFound().build();
         }
     }
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserVO> getUserInfo(@PathVariable Long userId) {
+        UserVO user = userService.getUserInfo(userId);
+        return ResponseEntity.ok(user);
+    }
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> deleteUser(@PathVariable Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.ok("User deleted successfully.");
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

issues : #26 

사용자 조회 및 삭제

사용자 조회 및 삭제 구현 및 Security에서 타입 잘못들어간거 하나 수정했습니다.

## ❓ 리뷰 요청사항 (선택)

로그인에서 user-service feignClient로 호출 할 때 /users/{username}을 통해 아이디로 Get했는데 유저 조회 할 때 /users/{userId}로 경로가 겹쳐 로그인 부분은 auth도 포함됐기 때문에 /users/auth/{username}으로 수정하여 해결했습니다. (임시로 해결했고 나중에 feignClient 다 같이 작업 할 때 통일하면 될 것 같습니다!) 
