### PR TITLE
[FEAT] Cookie JSESSIONID 제거 #81

### DIFF
--- a/com.sparta.logistics.client.auth/src/main/java/com/sparta/logistics/client/auth/application/security/JWTUtil.java
+++ b/com.sparta.logistics.client.auth/src/main/java/com/sparta/logistics/client/auth/application/security/JWTUtil.java
@@ -51,7 +51,7 @@ public class JWTUtil {
                 .compact();
 
         addJwtToCookie(token, response);
-
+        removeJSessionIdCookie(response);
         return token;
     }
 
@@ -108,5 +108,11 @@ public class JWTUtil {
                 .verifyWith(secretKey)
                 .build().parseSignedClaims(jwt).getPayload();
 
+    }
+    public void removeJSessionIdCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("JSESSIONID", null);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);  // 만료 시간 0으로 설정하여 쿠키 삭제
+        response.addCookie(cookie);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

issues: #81 

## 📝 작업 내용 요약

[FEAT] Cookie JSESSIONID 제거 #81
Cookie에 jsessionId가 같이 들어가는 오류가 있었어서 제거했습니다.