### PR TITLE
[FEAT] 회원 중복방지 로직 db, RoleCheck 어노테이션 복수 설정

### DIFF
--- a/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/controller/UserController.java
+++ b/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController extends CustomApiController {
         }
         return null;
     }
-    @RoleCheck("CUSTOMER")
+    @RoleCheck(roles = {"CUSTOMER", "MASTER"})
     @Operation(summary = "userId로 유저 검색", description = "userId로 유저 검색")
     @GetMapping("/{userId}")
     public ApiResult getUserInfo(@PathVariable Long userId) {

--- a/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/model/User.java
+++ b/com.sparta.logistics.client.user/src/main/java/com/sparta/logistics/client/user/model/User.java
@@ -18,13 +18,13 @@ public class User extends Timestamped {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String username;
 
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false, unique = true)

--- a/com.sparta.logistics.common/src/main/java/com/sparta/logistics/common/model/RoleCheck.java
+++ b/com.sparta.logistics.common/src/main/java/com/sparta/logistics/common/model/RoleCheck.java
@@ -8,5 +8,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RoleCheck {
-    String value();
+    String[] roles();
+//    String value();
 }

--- a/com.sparta.logistics.common/src/main/java/com/sparta/logistics/common/model/RoleCheckAspect.java
+++ b/com.sparta.logistics.common/src/main/java/com/sparta/logistics/common/model/RoleCheckAspect.java
@@ -10,6 +10,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.nio.file.AccessDeniedException;
+import java.util.Arrays;
 
 @Aspect
 @Component
@@ -24,10 +25,10 @@ public class RoleCheckAspect {
         System.out.println("User Role in Header: " + userRole); // 역할 정보 확인용 로그
 
         // 헤더에 역할이 존재하고, 그것이 애노테이션에서 요구하는 역할과 일치하는지 확인
-        if (userRole != null && userRole.equals(roleCheck.value())) {
+        if (userRole != null && Arrays.asList(roleCheck.roles()).contains(userRole)) {
             return joinPoint.proceed(); // 역할이 맞으면 메서드 실행
         } else {
-            throw new AccessDeniedException("Access denied. Required role: " + roleCheck.value());
+            throw new AccessDeniedException("Access denied. Required role: " + Arrays.toString(roleCheck.roles()));
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[FEAT] 회원 중복방지 로직 db #86 
[FEAT] RoleCheck 어노테이션 복수 설정가능 #87 

## 📝 작업 내용 요약

회원 중복방지 로직 db, RoleCheck 어노테이션 복수 설정

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
