### PR TITLE
[FEAT]  허브명 조회 API 기능 구현

### DIFF
--- a/com.sparta.logistics.client.hub/src/main/java/com/sparta/logistics/client/hub/controller/HubController.java
+++ b/com.sparta.logistics.client.hub/src/main/java/com/sparta/logistics/client/hub/controller/HubController.java
@@ -129,4 +129,16 @@ public class HubController extends CustomApiController {
         return apiResult;
     }
 
+    @GetMapping("delivery_managers/{hubName}")
+    public ApiResult getDeliveryManagers(@PathVariable("hubName") String hubName) {
+        ApiResult apiResult = new ApiResult(ApiResultError.ERROR_DEFAULT);
+        try {
+            HubResponseDto hubResponseDto = hubService.getDeliveryManagers(hubName);
+            apiResult.set(ApiResultError.NO_ERROR).setResultData(hubResponseDto);
+        } catch (HubException e) {
+            apiResult.set(e.getCode()).setResultMessage(e.getMessage());
+        }
+        return apiResult;
+    }
+
 }

--- a/com.sparta.logistics.client.hub/src/main/java/com/sparta/logistics/client/hub/repository/HubRepository.java
+++ b/com.sparta.logistics.client.hub/src/main/java/com/sparta/logistics/client/hub/repository/HubRepository.java
@@ -14,6 +14,12 @@ public interface HubRepository extends JpaRepository<Hub, UUID>, HubRepositoryCu
         return findByHubIdAndIsDeletedFalse(hubId);
     }
 
+    Optional<Hub> findByNameAndIsDeletedFalse(String name);
+
+    default Optional<Hub> findByHubName(String name) {
+        return findByNameAndIsDeletedFalse(name);
+    }
+
     List<Hub> findAllByIsDeletedFalse();
 
     boolean existsBySequenceAndIsDeletedFalse(Integer sequence);

--- a/com.sparta.logistics.client.hub/src/main/java/com/sparta/logistics/client/hub/service/HubService.java
+++ b/com.sparta.logistics.client.hub/src/main/java/com/sparta/logistics/client/hub/service/HubService.java
@@ -120,4 +120,11 @@ public class HubService {
             throw new HubException(ApiResultError.HUB_SEQUENCE_DUPLICATE);
         }
     }
+
+    public HubResponseDto getDeliveryManagers(String hubName) throws HubException {
+        Hub hub = hubRepository.findByHubName(hubName)
+                .orElseThrow(() -> new HubException(ApiResultError.HUB_NO_EXIST));
+
+        return HubResponseDto.of(hub);
+    }
 }


### PR DESCRIPTION
Issues: #117

## #️⃣ 연관된 이슈

#117 

## 📝 작업 내용 요약

- Hub 허브명 검색 API 구현
- 삭제되지 않은 허브만 검색가능 하도록 구현

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
